### PR TITLE
let json parser make-hashtable with equal?

### DIFF
--- a/json/parser.scm
+++ b/json/parser.scm
@@ -180,7 +180,7 @@
 
   (define (read-object parser)
     (let loop ((c (parser-peek-char parser))
-               (pairs (make-hash-table)))
+               (pairs (make-hashtable equal-hash equal?)))
       (case c
         ;; Skip whitespaces
         ((#\tab #\vtab #\newline #\return #\space)


### PR DESCRIPTION
因为在使用的时候发现，通过 (hashtable-ref ht "key" #f) 来取 json 数据的话，返回的永远是 #f，因此改成普通的 hashtable，而不是 eq-hashtable